### PR TITLE
Remove one frame loading when switching to different type of Color Input

### DIFF
--- a/presentation/color-input/impl/src/main/java/io/github/mmolosay/thecolor/presentation/input/impl/ColorInputViewModel.kt
+++ b/presentation/color-input/impl/src/main/java/io/github/mmolosay/thecolor/presentation/input/impl/ColorInputViewModel.kt
@@ -40,21 +40,19 @@ class ColorInputViewModel @AssistedInject constructor(
     private val _dataStateFlow = MutableStateFlow<DataState>(DataState.Loading)
     val dataStateFlow = _dataStateFlow.asStateFlow()
 
-    val hexViewModel: ColorInputHexViewModel by lazy {
+    val hexViewModel: ColorInputHexViewModel =
         hexViewModelFactory.create(
             coroutineScope = ViewModelCoroutineScope(parent = coroutineScope),
             mediator = mediator,
             eventStore = eventStore,
         )
-    }
 
-    val rgbViewModel: ColorInputRgbViewModel by lazy {
+    val rgbViewModel: ColorInputRgbViewModel =
         rgbViewModelFactory.create(
             coroutineScope = ViewModelCoroutineScope(parent = coroutineScope),
             mediator = mediator,
             eventStore = eventStore,
         )
-    }
 
     init {
         coroutineScope.launch(defaultDispatcher) {


### PR DESCRIPTION
Instantiate ViewModels for specific types of Color Input eagerly

This enables UI to show actual data straight away without one frame of showing initial data of ViewModels that are just created when UI appears