### PR TITLE
Introduce `ImmediateEventRelay`

### DIFF
--- a/presentation/common/api/build.gradle.kts
+++ b/presentation/common/api/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("javax.inject:javax.inject:1")
 
     // Testing
+    testImplementation(project(":utils:testing"))
     testImplementation("org.junit.jupiter:junit-jupiter-api:${libs.versions.junit.get()}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${libs.versions.junit.get()}")
     testImplementation("org.junit.jupiter:junit-jupiter-params:${libs.versions.junit.get()}")

--- a/presentation/common/api/src/main/java/io/github/mmolosay/thecolor/presentation/api/ConsumableNavEvent.kt
+++ b/presentation/common/api/src/main/java/io/github/mmolosay/thecolor/presentation/api/ConsumableNavEvent.kt
@@ -1,9 +1,0 @@
-package io.github.mmolosay.thecolor.presentation.api
-
-/**
- * An interface for a navigation event that is executed by UI and should be reported
- * as consumed (executed, reduced) via [onConsumed].
- */
-interface ConsumableNavEvent {
-    val onConsumed: () -> Unit
-}

--- a/presentation/common/api/src/main/java/io/github/mmolosay/thecolor/presentation/api/ImmediateEventRelay.kt
+++ b/presentation/common/api/src/main/java/io/github/mmolosay/thecolor/presentation/api/ImmediateEventRelay.kt
@@ -1,0 +1,54 @@
+package io.github.mmolosay.thecolor.presentation.api
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.withContext
+
+/*
+ * Related articles:
+ * 1. https://github.com/Kotlin/kotlinx.coroutines/issues/2886
+ * 2. https://proandroiddev.com/android-one-off-events-approaches-evolution-anti-patterns-add887cd0250
+ * 3. https://itnext.io/exercises-in-futility-one-time-events-in-android-ddbdd7b5bd1c
+ */
+/**
+ * A one-time event delivery mechanism for sending events to active collectors.
+ * Designed to be used to send one-time events from ViewModel to View, such as navigation events.
+ *
+ * Heavily relies on [Dispatchers.Main.immediate][kotlinx.coroutines.MainCoroutineDispatcher.immediate].
+ * [send] will switch to it for the caller, but [eventFlow] should be explicitly collected on client
+ * side (in View) in the context of `Dispatchers.Main.immediate`.
+ * Failing to do so may result in events being lost.
+ *
+ * Caution: due to executing on `Dispatchers.Main.immediate`, rapidly sending many events will
+ * noticeably load main thread, thus causing UI lags.
+ *
+ * Sent events are buffered and delivered in order to the first collector of [eventFlow].
+ * If no collector is active when an event is sent, the event will be retained and delivered when collection begins.
+ * If the event is never collected and the internal [channel] is cancelled or closed while still
+ * containing undelivered events, [onUndeliveredEvent] will be invoked.
+ */
+class ImmediateEventRelay<T : Any>(
+    onUndeliveredEvent: (T) -> Unit = ThrowErrorOnUndeliveredEvent,
+) {
+
+    private val channel = Channel<T>(
+        capacity = Channel.UNLIMITED, onUndeliveredElement = onUndeliveredEvent,
+    )
+
+    // MUST be collected from Dispatchers.Main.immediate
+    val eventFlow: Flow<T> = channel.receiveAsFlow()
+
+    suspend fun send(event: T) {
+        withContext(Dispatchers.Main.immediate) {
+            channel.send(event)
+        }
+    }
+}
+
+private data object ThrowErrorOnUndeliveredEvent : (Any) -> Unit {
+    override operator fun invoke(event: Any) {
+        throw Error("Undelivered event: $event")
+    }
+}

--- a/presentation/common/api/src/test/kotlin/io/github/mmolosay/thecolor/presentation/api/ImmediateEventRelayTest.kt
+++ b/presentation/common/api/src/test/kotlin/io/github/mmolosay/thecolor/presentation/api/ImmediateEventRelayTest.kt
@@ -1,0 +1,74 @@
+package io.github.mmolosay.thecolor.presentation.api
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImmediateEventRelayTest {
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `given there are no collectors, when events are sent and then collector appears, then all sent events are emitted from the flow`() {
+        val testDispatcher = UnconfinedTestDispatcher()
+        Dispatchers.setMain(testDispatcher)
+        runTest(testDispatcher) {
+            val sut = createSut()
+
+            val event1 = Event.Foo
+            sut.send(event1)
+            val event2 = Event.Bar("hello")
+            sut.send(event2)
+            val collectedEvents = mutableListOf<Event>()
+            sut.eventFlow.take(2).toList(collectedEvents)
+
+            collectedEvents shouldBe listOf(event1, event2)
+        }
+    }
+
+    @Test
+    fun `when two different events are sent concurrently, then both are emitted from the flow and none are lost`() {
+        val testDispatcher = StandardTestDispatcher()
+        Dispatchers.setMain(testDispatcher)
+        runTest(testDispatcher) {
+            val sut = createSut()
+
+            val collectedEvents = mutableListOf<Event>()
+            val collectionJob = launch {
+                sut.eventFlow.take(2).toList(collectedEvents)
+            }
+            advanceUntilIdle()
+            val event1 = Event.Foo
+            launch { sut.send(event1) }
+            val event2 = Event.Bar("hello")
+            launch { sut.send(event2) }
+            advanceUntilIdle()
+
+            collectedEvents shouldBe listOf(event1, event2)
+            collectionJob.cancel()
+        }
+    }
+
+    fun createSut() =
+        ImmediateEventRelay<Event>()
+
+    sealed interface Event {
+        data object Foo : Event
+        data class Bar(val payload: String) : Event
+    }
+}

--- a/presentation/home/src/main/java/io/github/mmolosay/thecolor/presentation/home/ui/HomeScreen.kt
+++ b/presentation/home/src/main/java/io/github/mmolosay/thecolor/presentation/home/ui/HomeScreen.kt
@@ -106,6 +106,7 @@ import io.github.mmolosay.thecolor.utils.cache.DequeCache
 import io.github.mmolosay.thecolor.utils.cache.PruneOnSizeThreshold
 import io.github.mmolosay.thecolor.utils.doNothing
 import io.github.mmolosay.thecolor.utils.stabilize
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -116,6 +117,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import kotlin.random.Random
 
 @Composable
@@ -239,7 +241,7 @@ internal typealias ColorCenterComposable = @Composable () -> Unit
 private fun HomeScreen(
     data: HomeData,
     strings: HomeUiStrings,
-    navEventFlow: Flow<HomeNavEvent?>,
+    navEventFlow: Flow<HomeNavEvent>,
     colorInput: @Composable () -> Unit,
     colorPreview: ColorPreviewWithDependencies,
     colorCenter: ColorCenterComposable?,
@@ -267,15 +269,15 @@ private fun HomeScreen(
     }
 
     LaunchedEffect(Unit) {
-        navEventFlow.collect { event ->
-            if (event == null) return@collect
-            when (event) {
-                is HomeNavEvent.GoToSettings -> {
-                    focusManager.clearFocus()
-                    navigateToSettings()
+        launch(Dispatchers.Main.immediate) {
+            navEventFlow.collect { event ->
+                when (event) {
+                    is HomeNavEvent.GoToSettings -> {
+                        focusManager.clearFocus()
+                        navigateToSettings()
+                    }
                 }
             }
-            event.onConsumed()
         }
     }
 }

--- a/presentation/home/src/main/java/io/github/mmolosay/thecolor/presentation/home/viewmodel/HomeNavEvent.kt
+++ b/presentation/home/src/main/java/io/github/mmolosay/thecolor/presentation/home/viewmodel/HomeNavEvent.kt
@@ -1,13 +1,9 @@
 package io.github.mmolosay.thecolor.presentation.home.viewmodel
 
-import io.github.mmolosay.thecolor.presentation.api.ConsumableNavEvent
-
 /**
- * A family of navigation events that may occur in home View.
+ * A family of navigation events that may occur in 'Home' ViewModel.
  */
-sealed interface HomeNavEvent : ConsumableNavEvent {
+sealed interface HomeNavEvent {
 
-    data class GoToSettings(
-        override val onConsumed: () -> Unit,
-    ) : HomeNavEvent
+    data object GoToSettings : HomeNavEvent
 }

--- a/presentation/home/src/main/java/io/github/mmolosay/thecolor/presentation/home/viewmodel/HomeViewModel.kt
+++ b/presentation/home/src/main/java/io/github/mmolosay/thecolor/presentation/home/viewmodel/HomeViewModel.kt
@@ -13,6 +13,7 @@ import io.github.mmolosay.thecolor.domain.repository.UserPreferencesRepository
 import io.github.mmolosay.thecolor.domain.usecase.ColorFactory
 import io.github.mmolosay.thecolor.domain.usecase.IsColorLightUseCase
 import io.github.mmolosay.thecolor.presentation.api.ColorToColorIntUseCase
+import io.github.mmolosay.thecolor.presentation.api.ImmediateEventRelay
 import io.github.mmolosay.thecolor.presentation.api.ViewModelCoroutineScope
 import io.github.mmolosay.thecolor.presentation.center.ColorCenterViewModel
 import io.github.mmolosay.thecolor.presentation.details.viewmodel.ColorDetailsCommand
@@ -41,6 +42,7 @@ import io.github.mmolosay.thecolor.utils.receiveAllUntil
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -121,8 +123,8 @@ class HomeViewModel @Inject constructor(
             .stateIn(viewModelScope, SharingStarted.Eagerly, initialValue)
     }
 
-    private val _navEventFlow = MutableStateFlow<HomeNavEvent?>(null)
-    val navEventFlow = _navEventFlow.asStateFlow()
+    private val navEventRelay = ImmediateEventRelay<HomeNavEvent>()
+    val navEventFlow = navEventRelay.eventFlow
 
     private val colorInputMediator: ColorInputMediator =
         colorInputMediatorFactory.create(
@@ -435,16 +437,16 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun setGoToSettingsNavEvent() {
+    private fun sendGoToSettingsNavEvent() {
         /*
          * Right now there's no logic in ViewModel that accompanies navigating to Settings.
          * In a real app, here would've been a logic for accepting / denying UI's navigation request
          * depending on the business logic. Here may also be sending data to analytics or logging.
          */
-        val event = HomeNavEvent.GoToSettings(
-            onConsumed = ::clearNavEvent,
-        )
-        _navEventFlow.value = event
+        viewModelScope.launch(Dispatchers.Main.immediate) {
+            val event = HomeNavEvent.GoToSettings
+            navEventRelay.send(event)
+        }
     }
 
     private fun clearProceedResult() {
@@ -459,10 +461,6 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun clearNavEvent() {
-        _navEventFlow.value = null
-    }
-
     private fun initialData(): HomeData {
         val canProceed = kotlin.run {
             val color = colorInputColorStore.colorFlow.value
@@ -473,7 +471,7 @@ class HomeViewModel @Inject constructor(
             proceedResult = null, // 'proceed' action wasn't invoked yet
             randomizeColor = ::randomizeColor,
             colorSchemeSelectedSwatchData = null, // no selected swatch initially
-            requestToGoToSettings = ::setGoToSettingsNavEvent,
+            requestToGoToSettings = ::sendGoToSettingsNavEvent,
         )
     }
 


### PR DESCRIPTION
Compared with previous approach using StateFlow and View acknowledging that event was processed, this new approach:
1. Delivers events to View quicker
2. Supports sending multiple events concurrently without losing / overwriting earlier ones